### PR TITLE
Add example for updating one project dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ and save to your `package.json`, run:
 david update
 ```
 
+To update a particular project dependency to the latest **stable** version,
+and save to your `package.json`, run:
+
+```sh
+david update package-name
+```
+
 You can also update global dependencies to latest versions:
 
 ```sh


### PR DESCRIPTION
I didn't realize that `david` could update single dependencies since all of the examples of updating are updating project dependencies or all global dependencies. This adds an example for updating one project dependency from the CLI.